### PR TITLE
Internal storage example

### DIFF
--- a/examples/ov5640_jpeg_kaluga1_3.py
+++ b/examples/ov5640_jpeg_kaluga1_3.py
@@ -10,11 +10,9 @@ tested on v1.3.
 The audio board must be mounted between the Kaluga and the LCD, it provides the
 I2C pull-ups(!)
 
-You also need to place ov5640_jpeg_kaluga1_3_boot.py at CIRCUITPY/boot.py
-and reset the board to make the internal flash readable by CircuitPython.
-You can make CIRCUITPY readable from your PC by booting CircuitPython in
-safe mode or holding the "MODE" button on the audio daughterboard while
-powering on or resetting the board.
+You also need to place ov5640_jpeg_kaluga1_3_boot.py at CIRCUITPY/boot.py.
+Then, hold the Mode button (button K2 on the audio board) while resetting the
+board to make the internal flash readable by CircuitPython.
 """
 
 import time

--- a/examples/ov5640_jpeg_kaluga1_3_boot.py
+++ b/examples/ov5640_jpeg_kaluga1_3_boot.py
@@ -5,7 +5,7 @@
 """Use this file as CIRCUITPY/boot.py in conjunction with ov5640_jpeg_kaluga1_3.py
 
 It makes the CIRCUITPY filesystem writable to CircuitPython
-(and read-only to the PC) unless the "MODE" button on the audio
+(and read-only to the PC) if the "MODE" button on the audio
 daughterboard is held while the board is powered on or reset.
 """
 
@@ -18,6 +18,6 @@ V_RECORD = 2.41
 
 a = analogio.AnalogIn(board.IO6)
 a_voltage = a.value * a.reference_voltage / 65535  # pylint: disable=no-member
-if abs(a_voltage - V_MODE) > 0.05:  # If mode is NOT pressed...
+if abs(a_voltage - V_MODE) < 0.05:  # If mode IS pressed...
     print("storage writable by CircuitPython")
     storage.remount("/", readonly=False)


### PR DESCRIPTION
@ladyada  looks like I _did_ commit this, but I improved it so the flow is not QUITE as bad.

 - install boot.py and code.py
 - restart whole holding k2 ("mode")
 - it'll run once and update CIRCUITPY/cam.jpg
 - then it restarts itself, so the host computer sees the updated content of cam.jpg, and CIRCUITPY is writable by the computer again
 - Now you can experiment with different resolution & quality settings as long as the capture fits within CIRCUITPY (~1MB)
