### PR TITLE
update for blit refactor to bitmaptools

### DIFF
--- a/examples/ov5640_stopmotion_kaluga1_3.py
+++ b/examples/ov5640_stopmotion_kaluga1_3.py
@@ -235,7 +235,26 @@ def take_stop_motion_gif(n_frames=10, replay_frame_time=0.3):
             g.add_frame(frame, replay_frame_time)
             for i in range(1, n_frames):
                 print(f"{i}/{n_frames}")
-                old_frame.blit(0, 0, frame, x1=0, y1=0, x2=frame.width, y2=frame.height)
+
+                # CircuitPython Versions <= 8.2.0
+                if hasattr(old_frame, "blit"):
+                    old_frame.blit(
+                        0, 0, frame, x1=0, y1=0, x2=frame.width, y2=frame.height
+                    )
+
+                # CircuitPython Versions >= 9.0.0
+                elif hasattr(bitmaptools, "blit"):
+                    bitmaptools.blit(
+                        old_frame,
+                        frame,
+                        0,
+                        0,
+                        x1=0,
+                        y1=0,
+                        x2=frame.width,
+                        y2=frame.height,
+                    )
+
                 frame = wait_record_pressed_update_display(False, cap)
                 g.add_frame(frame, replay_frame_time)
             print("done")

--- a/examples/ov5640_stopmotion_kaluga1_3.py
+++ b/examples/ov5640_stopmotion_kaluga1_3.py
@@ -243,7 +243,7 @@ def take_stop_motion_gif(n_frames=10, replay_frame_time=0.3):
                     )
 
                 # CircuitPython Versions >= 9.0.0
-                elif hasattr(bitmaptools, "blit"):
+                else:
                     bitmaptools.blit(
                         old_frame,
                         frame,


### PR DESCRIPTION
This change goes along with [#8136](https://github.com/adafruit/circuitpython/pull/8136) from the core.

I've added logic to check for which place `blit()` exists and use it from there, so this is both backwards and forwards compatible for now.