### PR TITLE
fix circup install instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install ov5640
+    circup install adafruit_ov5640
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Resolves the following issue for this library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407 for this library

Editted by: tekktrik (removing auto-linking issue)