### PR TITLE
revise calculation of JPEG buffer

### DIFF
--- a/adafruit_ov5640/__init__.py
+++ b/adafruit_ov5640/__init__.py
@@ -1236,7 +1236,9 @@ class OV5640(_SCCB16CameraBase):  # pylint: disable=too-many-instance-attributes
     def capture_buffer_size(self) -> int:
         """Return the size of capture buffer to use with current resolution & colorspace settings"""
         if self.colorspace == OV5640_COLOR_JPEG:
-            return self.width * self.height // self.quality
+            #  This is somewhat arbirary but seems to work for a wide range of JPEG images
+            #  the user can chose to further scale the buffer in the user code  if necessary
+            return 2 * (self.width * self.height // self.quality)
         if self.colorspace == OV5640_COLOR_GRAYSCALE:
             return self.width * self.height
         return self.width * self.height * 2


### PR DESCRIPTION
Addresses #29 

Change the calculation of the JPEG capture buffer to avoid corrupted captures.
the old calculation was width*height/quality
but this often resulted in the buffer being too small, especially for higher quality (lower resolution) images.

the new calculation doubles the size:
`2*width*height/quality`

This may be overkill, but does seem to work over a wide range of JPEG sizes and qualities.
We can discuss reducing it and accept more risk of errors.
setting the buffer to `width*height//5` also seems to work, but seems very difficult to explain...

These changes were tested with a Pico2W.

Using a PicoW there are still severe memory constraints. I was only able to use JPEG images of 160x120 (QQVGA)  

I was also able to capture JPEG images and write to an SD on a Pico.  
Using the PicoW to capture an image and send it to AIO was not viable, in my experience.

That is why I moved to the Pico2W to work on this.
