### PR TITLE
initialize saturation and effect to default values.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Introduction
     :alt: Build Status
 
 
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/psf/black
-    :alt: Code Style: Black
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+    :target: https://github.com/astral-sh/ruff
+    :alt: Code Style: Ruff
 
 CircuitPython driver for OV5640 Camera
 

--- a/adafruit_ov5640/__init__.py
+++ b/adafruit_ov5640/__init__.py
@@ -1118,6 +1118,8 @@ class OV5640(_SCCB16CameraBase):
         self._ev = 0
         self._white_balance = 0
         self.size = size
+        self._saturation = 0
+        self._effect = OV5640_SPECIAL_EFFECT_NONE
 
         if init_autofocus:
             self.autofocus_init()


### PR DESCRIPTION
Resolves: #34 

I tested successfully with Pico2 and cowbell camera with this change and confirmed different effects and saturation values are working as expected.

I also noticed while working on this that I didn't update the badge in the readme previously, this was one of the first ones I did while working out the process. I've made that change in this PR too.